### PR TITLE
feat: Multiple indexes for collection

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Cloud Firestore indexes enable simple and complex queries against documents in a
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:-----:|
 | database | The Firestore database id. Defaults to "(default)" | `string` | `(default)` | no |
+| collection | The collection name to create index for | `string` | n/a | yes |
 | indexes | The map of collection being indexed and the fields supported by this index | `map(list(map(string)))` | n/a | yes |
 | project\_id | The ID of the project in which the resource belongs | `string` | n/a | yes |
 | query\_scope | The scope at which a query is run. Possible values are: COLLECTION, COLLECTION_GROUP | `string` | `COLLECTION` | no |

--- a/examples/main.tf
+++ b/examples/main.tf
@@ -3,8 +3,9 @@ module firestore {
 
   project_id  = "project-id"
   query_scope = "COLLECTION_GROUP"
+  collection = "collection1"
   indexes = {
-    collection1 = [
+    index1 = [
       {
         field_path = "name"
         order = "ASCENDING"
@@ -14,7 +15,7 @@ module firestore {
         order = "ASCENDING"
       },
     ],
-    collection2 = [
+    index2 = [
       {
         field_path = "name"
         order = "ASCENDING"

--- a/main.tf
+++ b/main.tf
@@ -2,7 +2,7 @@ resource "google_firestore_index" "fs_index" {
   provider = google-beta
   for_each = var.indexes
 
-  collection  = each.key
+  collection  = var.collection
   project     = var.project_id
   query_scope = var.query_scope
   database    = var.database

--- a/variables.tf
+++ b/variables.tf
@@ -13,6 +13,11 @@ variable database {
   default     = "(default)"
 }
 
+variable collection {
+  description = "The collection name to create index for"
+  type        = string
+}
+
 variable query_scope {
   type        = string
   description = "The scope at which a query is run. Possible values are: COLLECTION, COLLECTION_GROUP"


### PR DESCRIPTION
To support multiple indexes per collection now the collection name passed  separately, and index-name are used to define the index.

To use this module also `terragrunt.hcl` should be fixed:
```
 locals {
   project_vars = read_terragrunt_config(find_in_parent_folders("project.hcl"))
+  collection = basename(get_terragrunt_dir())
 }
...
   yamldecode(
     file("${get_terragrunt_dir()}/indexes.yaml")),
     {
+      collection = local.collection,
       project_id = local.project_vars.locals.project_id
     }
 )
```